### PR TITLE
Fix exception with static actions

### DIFF
--- a/StatsHelix.Charizard/RoutingManager.cs
+++ b/StatsHelix.Charizard/RoutingManager.cs
@@ -401,7 +401,7 @@ namespace StatsHelix.Charizard
                         // TODO: regex support
                         var path = $"/{actionDef.Controller.Info.Prefix}{method.Name}";
 
-                        var actionResult = Expression.Call(controller, method, args);
+                        var actionResult = Expression.Call(method.IsStatic ? null : controller, method, args);
                         if (actionDef.IsSynchronous)
                             actionResult = Expression.Call(typeof(Task).GetMethod(nameof(Task.FromResult)).MakeGenericMethod(typeof(HttpResponse)), actionResult);
                         var lambda = Expression.Label(earlyReturn, actionResult);


### PR DESCRIPTION
This makes them usable at least.
The major motivation for a static action however is that you don't want to allocate the controller object
(and, perhaps, skip instance middleware). This is not actually supported right now and needs a rework.